### PR TITLE
Adds back decompression for Lynn.

### DIFF
--- a/npcs/vore/argo/pred_uargo.lua
+++ b/npcs/vore/argo/pred_uargo.lua
@@ -67,6 +67,8 @@ function interact(args)
 				if stopWatch[#victim] <= stageInterval then
 					reqRelease(args)
 					npc.say("^blue;<3")
+				else
+					stopWatch[#victim] = stopWatch[#victim] - stageInterval
 				end
 			else
 				reqRelease(args)


### PR DESCRIPTION
During the NPC update, the Lynn NPC got bugged.  The code that would decrease the timer and allow people to decompress themselves ended up getting accidentally removed.  This PR fixes that.

Fixes #109, #122, and #133.